### PR TITLE
Add multiple reference photos per person

### DIFF
--- a/code/backend/app/db.py
+++ b/code/backend/app/db.py
@@ -159,6 +159,14 @@ class Database:
             ).fetchall()
         return [dict(row) for row in rows]
 
+    def get_encoding_count(self, person_id: str) -> int:
+        with self.connect() as connection:
+            row = connection.execute(
+                "SELECT COUNT(*) as cnt FROM face_encodings WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+        return row["cnt"] if row else 0
+
     def list_encodings(self) -> list[StoredEncoding]:
         with self.connect() as connection:
             rows = connection.execute(

--- a/code/backend/app/main.py
+++ b/code/backend/app/main.py
@@ -59,6 +59,23 @@ def create_app(
             raise HTTPException(status_code=404, detail="Reference image not found")
         return Response(content=image_bytes, media_type="image/jpeg")
 
+    @app.post("/people/{person_id}/photos", status_code=204)
+    async def add_person_photo(person_id: str, file: UploadFile = File(...)) -> Response:
+        if app.state.db.get_person(person_id) is None:
+            raise HTTPException(status_code=404, detail="Person not found")
+        image_bytes = await file.read()
+        result = _encode_or_raise(app.state.recognizer, image_bytes)
+        if not result.encodings:
+            raise HTTPException(status_code=400, detail="No face detected in image")
+        app.state.db.add_face_encoding(person_id, result.encodings[0])
+        return Response(status_code=204)
+
+    @app.get("/people/{person_id}/photo-count")
+    def get_photo_count(person_id: str) -> dict:
+        if app.state.db.get_person(person_id) is None:
+            raise HTTPException(status_code=404, detail="Person not found")
+        return {"count": app.state.db.get_encoding_count(person_id)}
+
     @app.post("/people", response_model=Person)
     async def create_person(
         name: str = Form(...),

--- a/code/ios/Nemo/APIClient.swift
+++ b/code/ios/Nemo/APIClient.swift
@@ -85,6 +85,19 @@ struct APIClient {
         return try await send(request)
     }
 
+    func addPersonPhoto(id: String, imageData: Data, baseURL: String) async throws {
+        var request = try request(path: "/people/\(id)/photos", baseURL: baseURL)
+        request.httpMethod = "POST"
+        request.setMultipartBody(fields: [:], fileField: "file", fileName: "extra_photo.jpg", mimeType: "image/jpeg", data: imageData)
+        try await sendEmpty(request)
+    }
+
+    func personPhotoCount(id: String, baseURL: String) async throws -> Int {
+        let request = try request(path: "/people/\(id)/photo-count", baseURL: baseURL)
+        let result: [String: Int] = try await send(request)
+        return result["count"] ?? 0
+    }
+
     func deletePerson(id: String, baseURL: String) async throws {
         var request = try request(path: "/people/\(id)", baseURL: baseURL)
         request.httpMethod = "DELETE"

--- a/code/ios/Nemo/Views/ContentView.swift
+++ b/code/ios/Nemo/Views/ContentView.swift
@@ -798,6 +798,10 @@ private struct PersonDatabaseEditor: View {
     @State private var isSaving = false
     @State private var isDeleting = false
     @State private var errorMessage: String?
+    @State private var photoCount: Int = 0
+    @State private var isAddingPhoto = false
+    @State private var showPhotoPicker = false
+    @State private var addPhotoError: String?
 
     private let apiClient = APIClient()
 
@@ -826,6 +830,30 @@ private struct PersonDatabaseEditor: View {
                         size: 180
                     )
                     Spacer()
+                }
+            }
+
+            Section("Training Photos") {
+                HStack {
+                    Text("Saved encodings")
+                    Spacer()
+                    Text("\(photoCount)")
+                        .foregroundStyle(.secondary)
+                }
+                Button {
+                    showPhotoPicker = true
+                } label: {
+                    if isAddingPhoto {
+                        ProgressView()
+                    } else {
+                        Label("Add Another Photo", systemImage: "photo.badge.plus")
+                    }
+                }
+                .disabled(isAddingPhoto)
+                if let addPhotoError {
+                    Text(addPhotoError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
                 }
             }
 
@@ -863,6 +891,12 @@ private struct PersonDatabaseEditor: View {
                     Text(errorMessage)
                         .foregroundStyle(.red)
                 }
+            }
+        }
+        .task { await loadPhotoCount() }
+        .sheet(isPresented: $showPhotoPicker) {
+            PhotoPickerView { imageData in
+                Task { await uploadPhoto(imageData) }
             }
         }
         .navigationTitle("Edit Person")
@@ -922,6 +956,22 @@ private struct PersonDatabaseEditor: View {
             dismiss()
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadPhotoCount() async {
+        photoCount = (try? await apiClient.personPhotoCount(id: person.id, baseURL: backendURL)) ?? 0
+    }
+
+    private func uploadPhoto(_ imageData: Data) async {
+        isAddingPhoto = true
+        addPhotoError = nil
+        defer { isAddingPhoto = false }
+        do {
+            try await apiClient.addPersonPhoto(id: person.id, imageData: imageData, baseURL: backendURL)
+            photoCount += 1
+        } catch {
+            addPhotoError = error.localizedDescription
         }
     }
 }

--- a/code/ios/Nemo/Views/PhotoPickerView.swift
+++ b/code/ios/Nemo/Views/PhotoPickerView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import PhotosUI
+
+struct PhotoPickerView: View {
+    let onSelected: (Data) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedItem: PhotosPickerItem?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                PhotosPicker(selection: $selectedItem, matching: .images, photoLibrary: .shared()) {
+                    Label("Choose Photo", systemImage: "photo.on.rectangle")
+                        .font(.title3)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                }
+                .buttonStyle(.bordered)
+                .padding(.horizontal)
+                Spacer()
+            }
+            .navigationTitle("Add Photo")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .onChange(of: selectedItem) { _, item in
+                guard let item else { return }
+                Task {
+                    if let data = try? await item.loadTransferable(type: Data.self) {
+                        onSelected(data)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this does
Adds the ability to upload additional training photos for an existing person. The backend already supported multiple face encodings in the database, but there was no way to add more after initial creation. This fills that gap.

New endpoints:
- `POST /people/{id}/photos` - upload another photo and add its face encoding
- `GET /people/{id}/photo-count` - get how many encodings exist for a person

On the iOS side, the person editor now shows how many training photos are saved and has an "Add Another Photo" button that opens the photo picker.

## Why it matters
More reference photos from different angles, lighting conditions, and expressions leads to significantly better recognition accuracy, which is important for our use case.

## Testing
- Open an existing person in the editor and check the encoding count
- Add another photo and confirm the count goes up
- Try uploading a photo with no visible face and verify the error