### PR TITLE
Track when each person was last recognized

### DIFF
--- a/code/backend/app/db.py
+++ b/code/backend/app/db.py
@@ -34,7 +34,8 @@ class Database:
                     name TEXT NOT NULL,
                     description TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    reference_image BLOB
+                    reference_image BLOB,
+                    last_seen TEXT
                 );
 
                 CREATE TABLE IF NOT EXISTS face_encodings(
@@ -52,6 +53,8 @@ class Database:
             }
             if "reference_image" not in columns:
                 connection.execute("ALTER TABLE people ADD COLUMN reference_image BLOB")
+            if "last_seen" not in columns:
+                connection.execute("ALTER TABLE people ADD COLUMN last_seen TEXT")
 
     def create_person(self, name: str, description: str, reference_image: bytes | None = None) -> dict:
         person_id = str(uuid.uuid4())
@@ -69,6 +72,7 @@ class Database:
             "name": name,
             "description": description,
             "created_at": created_at,
+            "last_seen": None,
         }
 
     def add_face_encoding(self, person_id: str, encoding: list[float]) -> None:
@@ -85,7 +89,7 @@ class Database:
         with self.connect() as connection:
             row = connection.execute(
                 """
-                SELECT id, name, description, created_at
+                SELECT id, name, description, created_at, last_seen
                 FROM people
                 WHERE id = ?
                 """,
@@ -122,7 +126,7 @@ class Database:
 
             row = connection.execute(
                 """
-                SELECT id, name, description, created_at
+                SELECT id, name, description, created_at, last_seen
                 FROM people
                 WHERE id = ?
                 """,
@@ -152,12 +156,19 @@ class Database:
         with self.connect() as connection:
             rows = connection.execute(
                 """
-                SELECT id, name, description, created_at
+                SELECT id, name, description, created_at, last_seen
                 FROM people
                 ORDER BY created_at DESC
                 """
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def update_last_seen(self, person_id: str) -> None:
+        with self.connect() as connection:
+            connection.execute(
+                "UPDATE people SET last_seen = ? WHERE id = ?",
+                (_now(), person_id),
+            )
 
     def list_encodings(self) -> list[StoredEncoding]:
         with self.connect() as connection:

--- a/code/backend/app/main.py
+++ b/code/backend/app/main.py
@@ -122,6 +122,8 @@ def create_app(
             )
 
         person, distance = best
+        app.state.db.update_last_seen(person["id"])
+        person = app.state.db.get_person(person["id"])
         return RecognitionResponse(
             status="recognized",
             person=Person(**person),

--- a/code/backend/app/schemas.py
+++ b/code/backend/app/schemas.py
@@ -6,6 +6,7 @@ class Person(BaseModel):
     name: str
     description: str
     created_at: str
+    last_seen: str | None = None
 
 
 class PersonUpdate(BaseModel):

--- a/code/ios/Nemo/Models.swift
+++ b/code/ios/Nemo/Models.swift
@@ -9,12 +9,23 @@ struct Person: Codable, Identifiable, Equatable {
     let name: String
     let description: String
     let createdAt: String
+    let lastSeen: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case name
         case description
         case createdAt = "created_at"
+        case lastSeen = "last_seen"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        description = try c.decode(String.self, forKey: .description)
+        createdAt = try c.decode(String.self, forKey: .createdAt)
+        lastSeen = try c.decodeIfPresent(String.self, forKey: .lastSeen)
     }
 }
 

--- a/code/ios/Nemo/Views/ContentView.swift
+++ b/code/ios/Nemo/Views/ContentView.swift
@@ -360,6 +360,11 @@ private struct RecognitionResultView: View {
                     .font(.title3.weight(.semibold))
                 Text(person.description.isEmpty ? "No description." : person.description)
                     .foregroundStyle(.secondary)
+                if let lastSeen = person.lastSeen {
+                    Text("Last seen: \(formattedLastSeen(lastSeen))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             } else {
                 Text("No matching person found.")
                     .foregroundStyle(.secondary)
@@ -727,6 +732,11 @@ private struct PeopleDatabaseView: View {
                                         .font(.caption)
                                         .foregroundStyle(.tertiary)
                                         .lineLimit(1)
+                                    if let lastSeen = person.lastSeen {
+                                        Text("Last seen: \(formattedLastSeen(lastSeen))")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
                             }
                         }
@@ -835,6 +845,10 @@ private struct PersonDatabaseEditor: View {
                     .foregroundStyle(.secondary)
                 Text("Created: \(person.createdAt)")
                     .foregroundStyle(.secondary)
+                if let lastSeen = person.lastSeen {
+                    Text("Last seen: \(formattedLastSeen(lastSeen))")
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Editable Fields") {
@@ -924,4 +938,16 @@ private struct PersonDatabaseEditor: View {
             errorMessage = error.localizedDescription
         }
     }
+}
+
+private func formattedLastSeen(_ isoString: String) -> String {
+    var formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let date = formatter.date(from: isoString) ?? ISO8601DateFormatter().date(from: isoString)
+    guard let date else { return isoString }
+    let hours = Int(Date().timeIntervalSince(date) / 3600)
+    if hours < 1 { return "just now" }
+    if hours < 24 { return "\(hours)h ago" }
+    let days = hours / 24
+    return days == 1 ? "yesterday" : "\(days) days ago"
 }


### PR DESCRIPTION
## What this does
Records a timestamp whenever a person is successfully recognized, and surfaces that as a "last seen" time in the UI.

Backend changes:
- Added a nullable `last_seen` column to the people table (with migration for existing DBs)
- `last_seen` gets updated on every successful recognition call
- The field is returned as part of the Person object

iOS changes:
- Recognition results show "Last seen X ago" below the person's name
- The person list in the database view shows last seen as a caption
- The edit view shows last seen in the record info section

## Why it matters
For dementia patients and caregivers, knowing when someone last visited provides useful context and helps track social patterns over time.

## Testing
- Recognize a known person and confirm last_seen updates
- Check the person list and edit view to see the time displayed
- A brand new person with no recognitions should show nothing