### PR TITLE
Add caregiver notes field to Person

### DIFF
--- a/code/backend/app/db.py
+++ b/code/backend/app/db.py
@@ -34,7 +34,8 @@ class Database:
                     name TEXT NOT NULL,
                     description TEXT NOT NULL,
                     created_at TEXT NOT NULL,
-                    reference_image BLOB
+                    reference_image BLOB,
+                    notes TEXT NOT NULL DEFAULT ''
                 );
 
                 CREATE TABLE IF NOT EXISTS face_encodings(
@@ -52,23 +53,26 @@ class Database:
             }
             if "reference_image" not in columns:
                 connection.execute("ALTER TABLE people ADD COLUMN reference_image BLOB")
+            if "notes" not in columns:
+                connection.execute("ALTER TABLE people ADD COLUMN notes TEXT NOT NULL DEFAULT ''")
 
-    def create_person(self, name: str, description: str, reference_image: bytes | None = None) -> dict:
+    def create_person(self, name: str, description: str, notes: str = "", reference_image: bytes | None = None) -> dict:
         person_id = str(uuid.uuid4())
         created_at = _now()
         with self.connect() as connection:
             connection.execute(
                 """
-                INSERT INTO people(id, name, description, created_at, reference_image)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO people(id, name, description, created_at, reference_image, notes)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (person_id, name, description, created_at, reference_image),
+                (person_id, name, description, created_at, reference_image, notes),
             )
         return {
             "id": person_id,
             "name": name,
             "description": description,
             "created_at": created_at,
+            "notes": notes,
         }
 
     def add_face_encoding(self, person_id: str, encoding: list[float]) -> None:
@@ -85,7 +89,7 @@ class Database:
         with self.connect() as connection:
             row = connection.execute(
                 """
-                SELECT id, name, description, created_at
+                SELECT id, name, description, created_at, notes
                 FROM people
                 WHERE id = ?
                 """,
@@ -107,22 +111,22 @@ class Database:
             return None
         return row["reference_image"]
 
-    def update_person(self, person_id: str, name: str, description: str) -> dict | None:
+    def update_person(self, person_id: str, name: str, description: str, notes: str = "") -> dict | None:
         with self.connect() as connection:
             cursor = connection.execute(
                 """
                 UPDATE people
-                SET name = ?, description = ?
+                SET name = ?, description = ?, notes = ?
                 WHERE id = ?
                 """,
-                (name, description, person_id),
+                (name, description, notes, person_id),
             )
             if cursor.rowcount == 0:
                 return None
 
             row = connection.execute(
                 """
-                SELECT id, name, description, created_at
+                SELECT id, name, description, created_at, notes
                 FROM people
                 WHERE id = ?
                 """,
@@ -152,7 +156,7 @@ class Database:
         with self.connect() as connection:
             rows = connection.execute(
                 """
-                SELECT id, name, description, created_at
+                SELECT id, name, description, created_at, notes
                 FROM people
                 ORDER BY created_at DESC
                 """

--- a/code/backend/app/main.py
+++ b/code/backend/app/main.py
@@ -63,6 +63,7 @@ def create_app(
     async def create_person(
         name: str = Form(...),
         description: str = Form(""),
+        notes: str = Form(""),
         file: UploadFile = File(...),
     ) -> dict:
         image_bytes = await file.read()
@@ -73,6 +74,7 @@ def create_app(
         person = app.state.db.create_person(
             name=name,
             description=description,
+            notes=notes,
             reference_image=image_bytes,
         )
         app.state.db.add_face_encoding(person["id"], result.encodings[0])
@@ -89,6 +91,7 @@ def create_app(
             person_id=person_id,
             name=name,
             description=description,
+            notes=update.notes,
         )
         if person is None:
             raise HTTPException(status_code=404, detail="Person not found")

--- a/code/backend/app/schemas.py
+++ b/code/backend/app/schemas.py
@@ -6,11 +6,13 @@ class Person(BaseModel):
     name: str
     description: str
     created_at: str
+    notes: str = ""
 
 
 class PersonUpdate(BaseModel):
     name: str
     description: str
+    notes: str = ""
 
 
 class RecognitionResponse(BaseModel):

--- a/code/ios/Nemo/APIClient.swift
+++ b/code/ios/Nemo/APIClient.swift
@@ -50,11 +50,11 @@ struct APIClient {
         return try await send(request)
     }
 
-    func createPerson(name: String, description: String, imageData: Data, baseURL: String) async throws -> Person {
+    func createPerson(name: String, description: String, notes: String = "", imageData: Data, baseURL: String) async throws -> Person {
         var request = try request(path: "/people", baseURL: baseURL)
         request.httpMethod = "POST"
         request.setMultipartBody(
-            fields: ["name": name, "description": description],
+            fields: ["name": name, "description": description, "notes": notes],
             fileField: "file",
             fileName: "enrollment.jpg",
             mimeType: "image/jpeg",
@@ -78,10 +78,10 @@ struct APIClient {
         return try await sendOptionalData(request)
     }
 
-    func updatePerson(id: String, name: String, description: String, baseURL: String) async throws -> Person {
+    func updatePerson(id: String, name: String, description: String, notes: String = "", baseURL: String) async throws -> Person {
         var request = try request(path: "/people/\(id)", baseURL: baseURL)
         request.httpMethod = "PATCH"
-        request.setJSONBody(PersonUpdateRequest(name: name, description: description))
+        request.setJSONBody(PersonUpdateRequest(name: name, description: description, notes: notes))
         return try await send(request)
     }
 

--- a/code/ios/Nemo/Models.swift
+++ b/code/ios/Nemo/Models.swift
@@ -9,18 +9,30 @@ struct Person: Codable, Identifiable, Equatable {
     let name: String
     let description: String
     let createdAt: String
+    let notes: String
 
     enum CodingKeys: String, CodingKey {
         case id
         case name
         case description
         case createdAt = "created_at"
+        case notes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decode(String.self, forKey: .description)
+        createdAt = try container.decode(String.self, forKey: .createdAt)
+        notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
     }
 }
 
 struct PersonUpdateRequest: Codable {
     let name: String
     let description: String
+    let notes: String
 }
 
 struct RecognitionResponse: Codable, Equatable {

--- a/code/ios/Nemo/Views/ContentView.swift
+++ b/code/ios/Nemo/Views/ContentView.swift
@@ -795,6 +795,7 @@ private struct PersonDatabaseEditor: View {
     @Environment(\.dismiss) private var dismiss
     @State private var name: String
     @State private var description: String
+    @State private var notes: String
     @State private var isSaving = false
     @State private var isDeleting = false
     @State private var errorMessage: String?
@@ -813,6 +814,7 @@ private struct PersonDatabaseEditor: View {
         self.onDeleted = onDeleted
         _name = State(initialValue: person.name)
         _description = State(initialValue: person.description)
+        _notes = State(initialValue: person.notes)
     }
 
     var body: some View {
@@ -841,6 +843,11 @@ private struct PersonDatabaseEditor: View {
                 TextField("Name", text: $name)
                 TextField("Description", text: $description, axis: .vertical)
                     .lineLimit(3...6)
+            }
+
+            Section("Caregiver Notes") {
+                TextField("Notes (visible only to caregivers)", text: $notes, axis: .vertical)
+                    .lineLimit(3...8)
             }
 
             Section {
@@ -902,6 +909,7 @@ private struct PersonDatabaseEditor: View {
                 id: person.id,
                 name: trimmedName,
                 description: trimmedDescription,
+                notes: notes.trimmingCharacters(in: .whitespacesAndNewlines),
                 baseURL: backendURL
             )
             onSaved(updatedPerson)

--- a/code/ios/Nemo/Views/CreatePersonView.swift
+++ b/code/ios/Nemo/Views/CreatePersonView.swift
@@ -8,6 +8,7 @@ struct CreatePersonView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
     @State private var description = ""
+    @State private var notes = ""
     @State private var errorMessage: String?
     @State private var isSaving = false
 
@@ -20,6 +21,11 @@ struct CreatePersonView: View {
                     TextField("Name", text: $name)
                     TextField("Description", text: $description, axis: .vertical)
                         .lineLimit(3...6)
+                }
+
+                Section("Caregiver Notes") {
+                    TextField("Notes (visible only to caregivers)", text: $notes, axis: .vertical)
+                        .lineLimit(3...8)
                 }
 
                 Section {
@@ -77,6 +83,7 @@ struct CreatePersonView: View {
             let person = try await apiClient.createPerson(
                 name: name.trimmingCharacters(in: .whitespacesAndNewlines),
                 description: description.trimmingCharacters(in: .whitespacesAndNewlines),
+                notes: notes.trimmingCharacters(in: .whitespacesAndNewlines),
                 imageData: imageData,
                 baseURL: backendURL
             )

--- a/code/ios/Nemo/Views/PersonDetailView.swift
+++ b/code/ios/Nemo/Views/PersonDetailView.swift
@@ -24,6 +24,12 @@ struct PersonDetailView: View {
                     Text("Created: \(person.createdAt)")
                         .foregroundStyle(.secondary)
                 }
+
+                if !person.notes.isEmpty {
+                    Section("Caregiver Notes") {
+                        Text(person.notes)
+                    }
+                }
             }
 
             if let errorMessage {


### PR DESCRIPTION
## What this does
Adds a separate notes field to each person profile, distinct from the existing description field. The description is meant to be short and patient-facing. Notes are for caregivers to record longer context like medication schedules, visit patterns, or conversation topics.

Backend changes:
- Added notes column to the people table (with migration)
- Notes are accepted and returned through the API on create and update

iOS changes:
- Create Person form has a Caregiver Notes section with a multi-line text field
- The person editor has the same section for editing existing notes
- PersonDetailView shows notes in their own section when non-empty

## Why it matters
Caregivers need a place to store context about each person that goes beyond a one-liner description, without that context cluttering the patient-facing view.

## Testing
- Create a person with notes filled in and verify they save
- Edit notes for an existing person
- Confirm notes appear in PersonDetailView
- Confirm notes are separate from the description field