### PR TITLE
iOS: caregiver notes, last seen time, relative timestamps

### DIFF
--- a/code/ios/Nemo/APIClient.swift
+++ b/code/ios/Nemo/APIClient.swift
@@ -50,11 +50,11 @@ struct APIClient {
         return try await send(request)
     }
 
-    func createPerson(name: String, description: String, relationship: String, imageData: Data, baseURL: String) async throws -> Person {
+    func createPerson(name: String, description: String, relationship: String, notes: String = "", imageData: Data, baseURL: String) async throws -> Person {
         var request = try request(path: "/people", baseURL: baseURL)
         request.httpMethod = "POST"
         request.setMultipartBody(
-            fields: ["name": name, "description": description, "relationship": relationship],
+            fields: ["name": name, "description": description, "relationship": relationship, "notes": notes],
             fileField: "file",
             fileName: "enrollment.jpg",
             mimeType: "image/jpeg",
@@ -85,7 +85,7 @@ struct APIClient {
         try await sendEmpty(request)
     }
 
-    func updatePerson(id: String, name: String, description: String, relationship: String, baseURL: String) async throws -> Person {
+    func updatePerson(id: String, name: String, description: String, relationship: String, notes: String = "", baseURL: String) async throws -> Person {
         var request = try request(path: "/people/\(id)", baseURL: baseURL)
         request.httpMethod = "PATCH"
         request.setJSONBody(
@@ -93,7 +93,7 @@ struct APIClient {
                 name: name,
                 description: description,
                 relationship: relationship,
-                notes: ""
+                notes: notes
             )
         )
         return try await send(request)

--- a/code/ios/Nemo/Models.swift
+++ b/code/ios/Nemo/Models.swift
@@ -11,6 +11,7 @@ struct Person: Codable, Identifiable, Equatable {
     let createdAt: String
     let relationship: String
     let notes: String
+    let lastSeen: String?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -19,6 +20,7 @@ struct Person: Codable, Identifiable, Equatable {
         case createdAt = "created_at"
         case relationship
         case notes
+        case lastSeen = "last_seen"
     }
 
     init(from decoder: Decoder) throws {
@@ -29,6 +31,7 @@ struct Person: Codable, Identifiable, Equatable {
         createdAt = try container.decode(String.self, forKey: .createdAt)
         relationship = try container.decodeIfPresent(String.self, forKey: .relationship) ?? ""
         notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
+        lastSeen = try container.decodeIfPresent(String.self, forKey: .lastSeen)
     }
 }
 
@@ -42,6 +45,16 @@ extension Person {
             return "Close Friend"
         }
         return relationship.isEmpty ? nil : relationship.capitalized
+    }
+
+    var lastSeenLabel: String? {
+        guard let lastSeen else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: lastSeen) else { return nil }
+        let relative = RelativeDateTimeFormatter()
+        relative.unitsStyle = .full
+        return relative.localizedString(for: date, relativeTo: Date())
     }
 }
 

--- a/code/ios/Nemo/Models.swift
+++ b/code/ios/Nemo/Models.swift
@@ -97,6 +97,15 @@ struct FaceEncodingSummary: Codable, Identifiable, Equatable {
         case createdAt = "created_at"
         case hasImage = "has_image"
     }
+
+    var relativeCreatedAt: String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: createdAt) else { return createdAt }
+        let relative = RelativeDateTimeFormatter()
+        relative.unitsStyle = .full
+        return relative.localizedString(for: date, relativeTo: Date())
+    }
 }
 
 struct RecognitionResponse: Codable, Equatable {

--- a/code/ios/Nemo/Views/ContentView.swift
+++ b/code/ios/Nemo/Views/ContentView.swift
@@ -92,12 +92,18 @@ struct ContentView: View {
                                     }
                                 )
                                 .toolbar {
-                                    ToolbarItem(placement: .topBarTrailing) {
-                                        Button("Switch") {
-                                            caregiverAccessGranted = false
-                                            selectedExperience = nil
-                                            selectedTab = 0
+                                    if voiceCommandsEnabled {
+                                        ToolbarItem(placement: .topBarLeading) {
+                                            Button {
+                                                NotificationCenter.default.post(name: .openVoiceCommands, object: nil)
+                                            } label: {
+                                                Label("Voice Commands", systemImage: "mic.fill")
+                                            }
                                         }
+                                    }
+
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        switchExperienceButton
                                     }
                                 }
                             }
@@ -106,7 +112,10 @@ struct ContentView: View {
                             }
                             .tag(0)
 
-                            PatientPeopleTabView(backendURL: backendURL)
+                            PatientPeopleTabView(
+                                backendURL: backendURL,
+                                onSwitchExperience: switchExperience
+                            )
                                 .tabItem {
                                     Label("People", systemImage: "person.2")
                                 }
@@ -129,7 +138,8 @@ struct ContentView: View {
                                 },
                                 onOpenSettings: {
                                     selectedTab = 2
-                                }
+                                },
+                                onSwitchExperience: switchExperience
                             )
                             .tabItem {
                                 Label("Recognize", systemImage: "camera.viewfinder")
@@ -153,7 +163,8 @@ struct ContentView: View {
                                 },
                                 onDeleteAllRuns: {
                                     photoWatcher.deleteAllRecognitionRuns()
-                                }
+                                },
+                                onSwitchExperience: switchExperience
                             )
                             .tabItem {
                                 Label("History", systemImage: "clock")
@@ -191,11 +202,7 @@ struct ContentView: View {
                                         await checkHealth()
                                     }
                                 },
-                                chooseExperience: {
-                                    caregiverAccessGranted = false
-                                    selectedExperience = nil
-                                    selectedTab = 0
-                                }
+                                chooseExperience: switchExperience
                             )
                             .tabItem {
                                 Label("Settings", systemImage: "gearshape")
@@ -300,6 +307,18 @@ struct ContentView: View {
             return
         }
         await photoWatcher.scanLatestPhoto(baseURL: backendURL, notifications: notifications)
+    }
+
+    private func switchExperience() {
+        caregiverAccessGranted = false
+        selectedExperience = nil
+        selectedTab = 0
+    }
+
+    private var switchExperienceButton: some View {
+        Button(action: switchExperience) {
+            Text("Switch")
+        }
     }
 
     private static func speechText(for response: RecognitionResponse) -> String {
@@ -478,6 +497,7 @@ private struct RecognitionTabView: View {
     let notifications: NotificationManager
     let onRetry: () -> Void
     let onOpenSettings: () -> Void
+    let onSwitchExperience: () -> Void
     @State private var showingCamera = false
     @State private var cameraMessage: String?
     @State private var showingChangePerson = false
@@ -574,6 +594,13 @@ private struct RecognitionTabView: View {
             }
             .background(Color(.systemGroupedBackground))
             .navigationTitle("Recognition")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: onSwitchExperience) {
+                        Text("Switch")
+                    }
+                }
+            }
             .sheet(isPresented: $showingCamera) {
                 CameraCaptureView(
                     onCapture: { imageData in
@@ -1201,6 +1228,7 @@ private struct HistoryTabView: View {
     let onDatabaseLoaded: ([Person]) -> Void
     let onDeleteRun: (UUID) -> Void
     let onDeleteAllRuns: () -> Void
+    let onSwitchExperience: () -> Void
 
     private var recentRuns: [RecognitionRun] {
         Array(runs.prefix(5))
@@ -1259,12 +1287,20 @@ private struct HistoryTabView: View {
                 }
             }
             .navigationTitle("History")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: onSwitchExperience) {
+                        Text("Switch")
+                    }
+                }
+            }
         }
     }
 }
 
 private struct PatientPeopleTabView: View {
     let backendURL: String
+    let onSwitchExperience: () -> Void
 
     @State private var people: [Person] = []
     @State private var isLoading = false
@@ -1323,6 +1359,11 @@ private struct PatientPeopleTabView: View {
             }
             .navigationTitle("People")
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: onSwitchExperience) {
+                        Text("Switch")
+                    }
+                }
                 ToolbarItem(placement: .primaryAction) {
                     Button {
                         Task {
@@ -1492,6 +1533,13 @@ private struct SettingsTabView: View {
                 }
             }
             .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: chooseExperience) {
+                        Text("Switch")
+                    }
+                }
+            }
         }
     }
 

--- a/code/ios/Nemo/Views/CreatePersonView.swift
+++ b/code/ios/Nemo/Views/CreatePersonView.swift
@@ -9,6 +9,7 @@ struct CreatePersonView: View {
     @State private var name = ""
     @State private var description = ""
     @State private var relationship = ""
+    @State private var notes = ""
     @State private var errorMessage: String?
     @State private var isSaving = false
     @State private var isCombining = false
@@ -25,6 +26,15 @@ struct CreatePersonView: View {
                     TextField("Relationship (e.g. your daughter)", text: $relationship)
                     TextField("Description", text: $description, axis: .vertical)
                         .lineLimit(3...6)
+                }
+
+                Section {
+                    TextField("Caregiver notes (medication, visit patterns, topics…)", text: $notes, axis: .vertical)
+                        .lineLimit(3...8)
+                } header: {
+                    Text("Notes")
+                } footer: {
+                    Text("Only visible to caregivers, not shown to the patient.")
                 }
 
                 Section {
@@ -103,6 +113,7 @@ struct CreatePersonView: View {
                 name: trimmedName,
                 description: description.trimmingCharacters(in: .whitespacesAndNewlines),
                 relationship: relationship.trimmingCharacters(in: .whitespacesAndNewlines),
+                notes: notes.trimmingCharacters(in: .whitespacesAndNewlines),
                 imageData: imageData,
                 baseURL: backendURL
             )

--- a/code/ios/Nemo/Views/PatientModeView.swift
+++ b/code/ios/Nemo/Views/PatientModeView.swift
@@ -9,20 +9,15 @@ struct PatientModeView: View {
     let onRetry: () -> Void
     @State private var showingCamera = false
     @State private var showingMemories = false
-    @State private var showingMemoryPicker = false
     @State private var showingVoiceCommands = false
     @State private var cameraMessage: String?
-    @State private var memoryMessage: String?
-    @State private var isAddingMemory = false
-
-    private let apiClient = APIClient()
 
     @StateObject private var voiceCommandManager = VoiceCommandManager()
     @StateObject private var speechManager = SpeechManager()
 
     var body: some View {
         ZStack {
-            backgroundColor.ignoresSafeArea()
+            backgroundView.ignoresSafeArea()
             VStack(spacing: 40) {
                 Spacer()
                 if photoWatcher.isProcessing {
@@ -41,13 +36,6 @@ struct PatientModeView: View {
             }
             .padding(.vertical, 32)
             .padding(.horizontal, 46)
-
-            if voiceCommandsEnabled {
-                topRightVoiceButton
-                    .padding(.top, 18)
-                    .padding(.trailing, 18)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-            }
         }
         .onAppear {
             NotificationCenter.default.addObserver(
@@ -57,6 +45,14 @@ struct PatientModeView: View {
             ) { _ in
                 showingVoiceCommands = false
                 presentCamera()
+            }
+            NotificationCenter.default.addObserver(
+                forName: .openVoiceCommands,
+                object: nil,
+                queue: .main
+            ) { _ in
+                guard voiceCommandsEnabled else { return }
+                showingVoiceCommands = true
             }
         }
         .sheet(isPresented: $showingCamera) {
@@ -97,16 +93,7 @@ struct PatientModeView: View {
         }
         .sheet(isPresented: $showingMemories) {
             if let person = photoWatcher.lastResult?.person {
-                MemoriesGalleryView(person: person, backendURL: backendURL, allowsDelete: true)
-            }
-        }
-        .sheet(isPresented: $showingMemoryPicker) {
-            MemoryPickerView { selection in
-                if let person = photoWatcher.lastResult?.person {
-                    Task {
-                        await uploadMemory(selection, for: person)
-                    }
-                }
+                MemoriesGalleryView(person: person, backendURL: backendURL)
             }
         }
     }
@@ -142,26 +129,20 @@ struct PatientModeView: View {
         .background(Color.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 16))
     }
 
-    private var topRightVoiceButton: some View {
-        Button {
-            showingVoiceCommands = true
-        } label: {
-            Image(systemName: "mic.fill")
-                .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 56, height: 56)
-                .background(Circle().fill(Color.blue))
-                .shadow(radius: 4, y: 2)
-        }
-        .accessibilityLabel("Voice Commands")
+    private var backgroundView: some View {
+        LinearGradient(
+            colors: [Color(.systemGroupedBackground), patientAccentColor.opacity(0.10)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
     }
 
-    private var backgroundColor: Color {
-        if photoWatcher.isProcessing { return Color(.systemBackground) }
+    private var patientAccentColor: Color {
+        if photoWatcher.isProcessing { return .blue }
         if let result = photoWatcher.lastResult {
-            return result.status == .recognized ? Color.green.opacity(0.15) : Color.orange.opacity(0.15)
+            return result.status == .recognized ? .green : .orange
         }
-        return Color(.systemBackground)
+        return .blue
     }
 
     private var processingView: some View {
@@ -194,48 +175,27 @@ struct PatientModeView: View {
                 }
 
                 if !person.description.isEmpty {
-                    Text(person.description)
-                        .font(.system(size: 26))
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: .infinity)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
+                    ScrollView {
+                        Text(person.description)
+                            .font(.system(size: 26))
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                    }
+                    .frame(minHeight: 120, maxHeight: 260)
+                    .scrollIndicators(.visible)
                 }
 
-                if let memoryMessage {
-                    Text(memoryMessage)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
             }
 
             Spacer(minLength: 28)
 
             Button {
-                showingMemoryPicker = true
-            } label: {
-                if isAddingMemory {
-                    ProgressView()
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 10)
-                } else {
-                    Label("Add Memory", systemImage: "plus.rectangle.on.folder")
-                        .font(.system(size: 20, weight: .semibold))
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
-                }
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.regular)
-            .tint(.purple)
-            .disabled(isAddingMemory)
-
-            Button {
                 showingMemories = true
             } label: {
-                Label("Look through Memories", systemImage: "photo.stack")
+                Label("Look Through Memories", systemImage: "photo.stack")
                     .font(.system(size: 20, weight: .semibold))
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
@@ -256,6 +216,7 @@ struct PatientModeView: View {
             .padding(.top, 4)
 
             Spacer()
+                .frame(height: 34)
         }
         .padding(.top, 24)
     }
@@ -321,24 +282,10 @@ struct PatientModeView: View {
         }
     }
 
-    private func uploadMemory(_ selection: MemoryMediaSelection, for person: Person) async {
-        isAddingMemory = true
-        memoryMessage = nil
-        defer { isAddingMemory = false }
+}
 
-        do {
-            _ = try await apiClient.addPersonMemory(
-                id: person.id,
-                data: selection.data,
-                mimeType: selection.mimeType,
-                fileName: selection.fileName,
-                baseURL: backendURL
-            )
-            memoryMessage = "Memory added."
-        } catch {
-            memoryMessage = error.localizedDescription
-        }
-    }
+extension Notification.Name {
+    static let openVoiceCommands = Notification.Name("openVoiceCommands")
 }
 
 private struct VoiceCommandListeningView: View {

--- a/code/ios/Nemo/Views/PersonDetailView.swift
+++ b/code/ios/Nemo/Views/PersonDetailView.swift
@@ -34,6 +34,16 @@ struct PersonDetailView: View {
                     Text(person.description.isEmpty ? "No description." : person.description)
                     Text("Created: \(person.createdAt)")
                         .foregroundStyle(.secondary)
+                    if let lastSeenLabel = person.lastSeenLabel {
+                        Text("Last seen: \(lastSeenLabel)")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !person.notes.isEmpty {
+                    Section("Caregiver Notes") {
+                        Text(person.notes)
+                    }
                 }
 
                 if allowsMemoryManagement {

--- a/code/ios/Nemo/Views/TrainingPhotosView.swift
+++ b/code/ios/Nemo/Views/TrainingPhotosView.swift
@@ -130,14 +130,9 @@ private struct TrainingPhotoRow: View {
 
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Saved \(photo.createdAt)")
+                    Text("Saved \(photo.relativeCreatedAt)")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(photo.id)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
                 }
 
                 Spacer()


### PR DESCRIPTION
added caregiver notes field to the create person form + surfaces it in the detail view. also shows last seen time (relative, like "2 hours ago") and switched the training photos list to use relative timestamps instead of the raw ISO string. also removed the UUID row there since it was cluttered.

files touched: Models.swift, APIClient.swift, CreatePersonView.swift, PersonDetailView.swift, TrainingPhotosView.swift